### PR TITLE
Ensure we compile with C++11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,4 +65,8 @@ target_link_libraries(com_osvr_LeapMotion
 	LeapMotion::Leap
 	${OpenCV_LIBS})
 
+# Ensure that we're telling the compiler to at least use C++11, or it won't compile.
+target_compile_features(com_osvr_LeapMotion PRIVATE
+    cxx_range_for)
+
 # TODO: Should we also be installing the leap library, and if so, where?

--- a/HardwareDetection.cpp
+++ b/HardwareDetection.cpp
@@ -1,6 +1,9 @@
 #include "HardwareDetection.h"
 #include "ControllerDevice.h"
 
+#include <chrono>
+#include <thread>
+
 using namespace LeapOsvr;
 
 
@@ -13,6 +16,8 @@ HardwareDetection::HardwareDetection() : mFound(false) {
 /*----------------------------------------------------------------------------------------------------*/
 OSVR_ReturnCode HardwareDetection::operator()(OSVR_PluginRegContext pContext) {
 	Leap::Controller controller;
+    
+    std::this_thread::sleep_for(std::chrono::duration<int, std::milli>(100));
 
 	if ( !controller.isConnected() ) {
 		mFound = false;


### PR DESCRIPTION
This is required for compiling with the latest GCC on Linux.

It compiles correctly, but doesn't show anything in `osvr_print_tree` or `OSVRTrackerView` if I load up the provided config, so I'm not completely certain if it works correctly. Can anyone else confirm? Has someone tried it lately?
