### PR TITLE
Wait for Leap controller to respond that device is connected

### DIFF
--- a/HardwareDetection.cpp
+++ b/HardwareDetection.cpp
@@ -3,6 +3,7 @@
 
 using namespace LeapOsvr;
 
+static const auto PREFIX = "[OSVR-Leap-Motion] ";
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////
 /*----------------------------------------------------------------------------------------------------*/
@@ -12,17 +13,31 @@ HardwareDetection::HardwareDetection() : mFound(false) {
 
 /*----------------------------------------------------------------------------------------------------*/
 OSVR_ReturnCode HardwareDetection::operator()(OSVR_PluginRegContext pContext) {
-	Leap::Controller controller;
+    Leap::Controller controller;
 
-	if ( !controller.isConnected() ) {
-		mFound = false;
-		return OSVR_RETURN_FAILURE;
-	}
+    if (!controller.isConnected()) {
+        /// sometimes it takes a little while for device to respond
+        std::cout << PREFIX << "Waiting for Leap Motion controller to connect"
+                  << std::endl;
+        int numTries = 0;
+        /// wait for a second for device to respond
+        while (!controller.isConnected() && numTries++ < 5) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(200));
+        }
+        if (controller.isConnected()) {
+            std::cout << PREFIX << "Controller is connected" << std::endl;
+        } else {
+            std::cout << PREFIX << "Controller is not connected" << std::endl;
+            mFound = false;
+            return OSVR_RETURN_FAILURE;
+        }
+    }
 
-	if ( !mFound ) {
-		mFound = true;
-		osvr::pluginkit::registerObjectForDeletion(pContext, new ControllerDevice(pContext));
-	}
+    if (!mFound) {
+        mFound = true;
+        osvr::pluginkit::registerObjectForDeletion(
+            pContext, new ControllerDevice(pContext));
+    }
 
-	return OSVR_RETURN_SUCCESS;
+    return OSVR_RETURN_SUCCESS;
 }

--- a/HardwareDetection.h
+++ b/HardwareDetection.h
@@ -1,4 +1,6 @@
 #include <osvr/PluginKit/PluginKit.h>
+#include <chrono>
+#include <thread>
 
 namespace LeapOsvr {
 	


### PR DESCRIPTION
I found that sometimes it takes a little while for Leap Motion controller to respond that device is connected. The plugin only checks once during HardwareDetection, which is usually too fast for controller to respond. I added a condition to check if device is connected a few times before giving up on it.
